### PR TITLE
Fix issue when deploying to the :rw Management Server

### DIFF
--- a/deploy-aas-db/v1/deploy-aas-db.psm1
+++ b/deploy-aas-db/v1/deploy-aas-db.psm1
@@ -355,7 +355,7 @@ General notes
 #>
 function AddCurrentServerToASFirewall($Server, $Credentials, $AzContext, $IpDetectionMethod , $StartIPAddress, $EndIPAddress) {
     $qry = "<Discover xmlns='urn:schemas-microsoft-com:xml-analysis'><RequestType>DISCOVER_PROPERTIES</RequestType><Restrictions/><Properties/></Discover>"
-    $serverName = $Server.Split('/')[3];
+    $serverName = $Server.Split('/')[3].Replace(':rw','');
     $added = $false
     switch ($IpDetectionMethod) {
         "ipAddressRange" {
@@ -426,7 +426,7 @@ An example
 General notes
 #>
 function RemoveCurrentServerFromASFirewall($Server, $AzContext) {
-    $serverName = $Server.Split('/')[3];
+    $serverName = $Server.Split('/')[3].Replace(':rw','');
     try {
         $currentConfig = (Get-AzureRmAnalysisServicesServer -Name $serverName -DefaultProfile $AzContext)[0].FirewallConfig
         $newFirewallRules = $currentConfig.FirewallRules

--- a/execute-aas-tmsl/v1/execute-aas-tmsl.psm1
+++ b/execute-aas-tmsl/v1/execute-aas-tmsl.psm1
@@ -185,7 +185,7 @@ General notes
 #>
 function AddCurrentServerToASFirewall($Server, $Credentials, $AzContext, $IpDetectionMethod , $StartIPAddress, $EndIPAddress) {
     $qry = "<Discover xmlns='urn:schemas-microsoft-com:xml-analysis'><RequestType>DISCOVER_PROPERTIES</RequestType><Restrictions/><Properties/></Discover>"
-    $serverName = $Server.Split('/')[3];
+    $serverName = $Server.Split('/')[3].Replace(':rw','');
     $added = $false
     switch ($IpDetectionMethod) {
         "ipAddressRange" {
@@ -256,7 +256,7 @@ An example
 General notes
 #>
 function RemoveCurrentServerFromASFirewall($Server, $AzContext) {
-    $serverName = $Server.Split('/')[3];
+    $serverName = $Server.Split('/')[3].Replace(':rw','');
     try {
         $currentConfig = (Get-AzureRmAnalysisServicesServer -Name $serverName -DefaultProfile $AzContext)[0].FirewallConfig
         $newFirewallRules = $currentConfig.FirewallRules


### PR DESCRIPTION
In Azure Analysis Services it is possible to deploy to a special Management Server by using the special :rw (read-write) qualifier. This way you are able to deploy to the processing server without impacting your querying pool during deployment. After deployment you perform a synchronization to promote the changes in your processing server to the querying pool. Please see the scale-out documentation for more information https://docs.microsoft.com/en-us/azure/analysis-services/analysis-services-scale-out.

Currently when using this special qualifier the deployment tasks fails with the following error: "Error during adding firewall rule (Could not find server: '[servername]:rw' in any resource group in the currently selected subscription: [subscriptionid]. Please ensure this server exists and that the current user has access to it.)"

This is happening because all the used cmdlets used for deployment work with this special qualifier but the Get-AzureRmAnalysisServicesServer and Set-AzureRmAnalysisServicesServer do **not**. These are being used to add and remove the firewall rule and they only work with the actual server name. Therfore, the :rw part should be stripped from the server name if it is there.