### PR TITLE
Support for Legacy Data source Update

### DIFF
--- a/deploy-aas-db/README.md
+++ b/deploy-aas-db/README.md
@@ -17,7 +17,7 @@ Analysis Service Details:
 - **Analysis Service name** - The name of the Azure Analysis Service server
 - **Login type** - Type of Azure Analysis Service login: Named user or Service Principal
 
-If **Login type** option is 'ervice Principal':
+If **Login type** option is 'Service Principal':
 - **Azure AD TenantID** - Azure ID Tenant ID
 - **Application ID** - Application ID of the Service Principal
 - **Application Key** - Key of the Application ID

--- a/deploy-aas-db/v1/deploy-aas-db.psm1
+++ b/deploy-aas-db/v1/deploy-aas-db.psm1
@@ -118,7 +118,7 @@ function ApplySQLSecurity($Model, $Server, $Database, $UserName, $Password) {
     $credential = ConvertFrom-Json '{"credential":{"AuthenticationKind":"UsernamePassword","kind":"kind","path":"server","Username":"user","Password":"pass","EncryptConnection":true}}'
     $dataSources = $Model.model.dataSources
     foreach($dataSource in $dataSources) {
-        if ($dataSource.type) {
+        if ($dataSource.type -and $dataSource.connectionDetails) {
             $connectionDetails.connectionDetails.protocol = $dataSource.connectionDetails.protocol
             $connectionDetails.connectionDetails.address.server = $Server
             $connectionDetails.connectionDetails.address.database = $Database
@@ -130,6 +130,10 @@ function ApplySQLSecurity($Model, $Server, $Database, $UserName, $Password) {
             $credential.credential.Username = $UserName
             $credential.credential.Password = $Password
             $dataSource.credential = $credential.credential
+        }
+        else {
+         $dataSource.connectionString = "Provider=SQLOLEDB;Data Source=" + $Server + ";User ID=" + $UserName + ";Password=" + $Password + ";Initial Catalog=" + $Database
+		 $dataSource.impersonationMode = "ImpersonateServiceAccount"
         }
     }
     return $Model


### PR DESCRIPTION
Hey @liprec  :

Added support to update Legacy data source.
Legacy format :
ConnectionString   : Persist Security Info=false;User ID=abc@1;Encrypt=true;TrustServerCertificate=false;Data 
                     Source=abc.database.windows.net;Initial Catalog=xyz
ImpersonationMode  : ImpersonateServiceAccount

New format :
ConnectionDetails  : {"protocol":"tds","address":{"server":"abc.database.windows.net","database":"
                     xyz"},"authentication":null,"query":null}
Options            : {}
Credential         : {"AuthenticationKind":"UsernamePassword","Username":"abc@1","EncryptConnection":true,"Privac
                     ySetting":"Private"}

So for legacy sources, DataSources.connectionDetails is null thereby leading to False condition and going to else part