### PR TITLE
liprec#53 update condition check for firewall rule deletion

### DIFF
--- a/deploy-aas-db/v1/deploy-aas-db.ps1
+++ b/deploy-aas-db/v1/deploy-aas-db.ps1
@@ -118,7 +118,7 @@ switch ($connectionType) {
 $tmslCommand = PrepareCommand -Model $model -Overwrite $overwrite -ModelName $modelName
 
 # Remove leftover firewall rule
-if (($deleteFirewallRule) -and ($addedFirewallRule)) {
+if ($deleteFirewallRule) {
     Write-Verbose "Remove leftover firewall rule"
     RemoveCurrentServerFromASFirewall -Server $aasServer -AzContext $azContext
 }


### PR DESCRIPTION
Scenario: when aas is taking long to load model, our developer may cancel the job. This leaves a firewall rule named vsts-release-aas. When the job is executed again, a naming conflict prevents the job from proceeding.
A similar issue was reported in #35 but the code addition in commit 1e3f5e5 will not work because variable $addedFirewallRule, never previously referenced, was null and thus interpreted as false. This causes the condition door to remain closed in all circumstances. The variable $addedFirewallRule should be removed.

commit e42d894 proposed to remove undeclared variable addedFirewallRule from condition check

