### PR TITLE
Change name of Analysis Services name field

### DIFF
--- a/execute-aas-tmsl/v1/task.json
+++ b/execute-aas-tmsl/v1/task.json
@@ -76,10 +76,10 @@
         {
             "name": "aasServer",
             "type": "string",
-            "label": "Analysis Services name",
+            "label": "Analysis Services Server",
             "defaultValue": "",
             "required": "true",
-            "helpMarkDown": "Azure Analysis Services name, like 'asazure://westeurope.asazure.windows.net/fabrikam'.",
+            "helpMarkDown": "Azure Analysis Services Server name, like 'asazure://westeurope.asazure.windows.net/fabrikam'.",
             "groupname": "aas"
         },
         {


### PR DESCRIPTION
Hi, the change it's only visual.
Propose to change the "Analysis Services name" for "Analysis Services Server", just like azure field. 
For me was confusing that in "Analysis Services name" have to put the actual server.
Thanks in advance